### PR TITLE
Add explicit matrix permissions example

### DIFF
--- a/charts/jenkins/VALUES.md
+++ b/charts/jenkins/VALUES.md
@@ -75,7 +75,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | [awsSecurityGroupPolicies.policies[0].securityGroupIds](./values.yaml#L1363) | list |  | `[]` |
 | [checkDeprecation](./values.yaml#L1357) | bool | Checks if any deprecated values are used | `true` |
 | [clusterZone](./values.yaml#L21) | string | Override the cluster name for FQDN resolving | `"cluster.local"` |
-| [controller.JCasC.authorizationStrategy](./values.yaml#L542) | string | Jenkins Config as Code Authorization Strategy-section | `"loggedInUsersCanDoAnything:\n  allowAnonymousRead: false"` |
+| [controller.JCasC.authorizationStrategy](./values.yaml#L542) | string | Jenkins Config as Code Authorization Strategy-section | `"globalMatrix:\n  entries:\n    - group:\n        name: \"authenticated\"\n        permissions:\n          - \"Overall/Administer\"\n    - user:\n        name: \"anonymous\"\n        permissions:\n          - \"Overall/Read\"\n    - user:\n        name: \"deept.shukla@solvei8.com\"\n        permissions:\n          - \"Overall/Administer\"\n          - \"Overall/Read\""` |
 | [controller.JCasC.configMapAnnotations](./values.yaml#L547) | object | Annotations for the JCasC ConfigMap | `{}` |
 | [controller.JCasC.configScripts](./values.yaml#L516) | object | List of Jenkins Config as Code scripts | `{}` |
 | [controller.JCasC.configUrls](./values.yaml#L513) | list | Remote URLs for configuration files. | `[]` |

--- a/charts/jenkins/ci/other-values.yaml
+++ b/charts/jenkins/ci/other-values.yaml
@@ -6,8 +6,21 @@ controller:
   fsGroup: 1000
   JCasC:
     authorizationStrategy: |-
-      loggedInUsersCanDoAnything:
-        allowAnonymousRead: true
+      globalMatrix:
+        entries:
+          - group:
+              name: "authenticated"
+              permissions:
+                - "Overall/Administer"
+          - user:
+              name: "anonymous"
+              permissions:
+                - "Overall/Read"
+          - user:
+              name: "deept.shukla@solvei8.com"
+              permissions:
+                - "Overall/Administer"
+                - "Overall/Read"
     securityRealm: |-
       ldap:
         configurations:

--- a/docs/eks-oauth-guide.md
+++ b/docs/eks-oauth-guide.md
@@ -74,7 +74,9 @@ controller:
       nginx.ingress.kubernetes.io/auth-signin: https://oauth2.example.com/oauth2/start?rd=/redirect/$http_host$escaped_request_uri
 ```
 
-Set up matrix authorization in JCasC so anonymous users are read only and authenticated users are admins. Place the configuration under `controller.JCasC.configScripts`:
+Set up matrix authorization in JCasC so anonymous users can only read while the
+authenticated group and specific admin accounts have full control. Place the
+configuration under `controller.JCasC.configScripts`:
 
 ```yaml
 controller:
@@ -88,9 +90,20 @@ controller:
               forwardedEmail: "X-Auth-Request-Email"
           authorizationStrategy:
             globalMatrix:
-              permissions:
-                - "Overall/Read:anonymous"
-                - "Overall/Administer:authenticated"
+              entries:
+                - group:
+                    name: "authenticated"
+                    permissions:
+                      - "Overall/Administer"
+                - user:
+                    name: "anonymous"
+                    permissions:
+                      - "Overall/Read"
+                - user:
+                    name: "deept.shukla@solvei8.com"
+                    permissions:
+                      - "Overall/Administer"
+                      - "Overall/Read"
 ```
 
 ## 4. Installing the chart


### PR DESCRIPTION
## Summary
- show example of using matrix-based permissions
- document example in VALUES.md
- update OAuth guide to reference explicit matrix security settings

## Testing
- `helm unittest --strict -f 'unittests/*.yaml' charts/jenkins`

------
https://chatgpt.com/codex/tasks/task_e_6841c3e816d883258b83006d22eac2c4