### PR TITLE
Add Jenkins pipeline examples with Kaniko

### DIFF
--- a/docs/Dockerfile.jenkins
+++ b/docs/Dockerfile.jenkins
@@ -1,0 +1,12 @@
+FROM jenkins/jenkins:lts
+
+USER root
+RUN jenkins-plugin-cli --plugins \
+    kubernetes \
+    workflow-aggregator \
+    git \
+    configuration-as-code \
+    credentials-binding \
+    aws-credentials
+
+USER jenkins

--- a/docs/docker-config.json
+++ b/docs/docker-config.json
@@ -1,0 +1,5 @@
+{
+  "credHelpers": {
+    "<account>.dkr.ecr.<region>.amazonaws.com": "ecr-login"
+  }
+}

--- a/docs/enhanced-Jenkinsfile
+++ b/docs/enhanced-Jenkinsfile
@@ -1,0 +1,93 @@
+pipeline {
+    environment {
+        // ECR repository to push the final image
+        ECR_REPO = '<account>.dkr.ecr.<region>.amazonaws.com/nsp_auth'
+    }
+    agent {
+        kubernetes {
+            yaml '''
+apiVersion: v1
+kind: Pod
+spec:
+  volumes:
+  - name: ivy-cache
+    emptyDir: {}
+  - name: sbt-creds
+    secret:
+      secretName: sbt-publish-creds
+      items:
+      - key: credentials
+        path: .credentials
+  - name: docker-config
+    configMap:
+      name: docker-config
+  containers:
+  - name: sbt
+    image: 185889327143.dkr.ecr.ap-southeast-1.amazonaws.com/sbt-0.13
+    command:
+    - cat
+    tty: true
+    volumeMounts:
+    - name: ivy-cache
+      mountPath: /root/.ivy2/cache
+    - name: sbt-creds
+      mountPath: /root/.ivy2/.credentials
+      subPath: .credentials
+  - name: kaniko
+    image: gcr.io/kaniko-project/executor:v1.20.1
+    command:
+    - cat
+    tty: true
+    volumeMounts:
+    - name: ivy-cache
+      mountPath: /root/.ivy2/cache
+    - name: docker-config
+      mountPath: /kaniko/.docker
+'''
+        }
+    }
+    options {
+        ansiColor('xterm')
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr: '5'))
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                echo "Cloning ${env.SERVICE_REPO_URL}"
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "${params.branch}"]],
+                    userRemoteConfigs: [[
+                        url: env.SERVICE_REPO_URL,
+                        credentialsId: env.CREDENTIALS_ID
+                    ]],
+                    extensions: [[
+                        $class: 'CloneOption',
+                        depth: 1,
+                        shallow: true,
+                        noTags: true,
+                        timeout: 10
+                    ]]
+                ])
+            }
+        }
+        stage('SBT Build') {
+            steps {
+                container('sbt') {
+                    sh 'sbt -mem 2048 clean update compile'
+                }
+            }
+        }
+        stage('Build & Push Docker Image') {
+            steps {
+                container('kaniko') {
+                    withCredentials([usernamePassword(credentialsId: 'aws-ecr-creds', usernameVariable: 'AWS_ACCESS_KEY_ID', passwordVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+                        sh '/kaniko/executor --dockerfile=Dockerfile --context=. --destination=${ECR_REPO}:${BUILD_NUMBER}'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/enhanced-seed-job.groovy
+++ b/docs/enhanced-seed-job.groovy
@@ -1,0 +1,60 @@
+// Jenkins seed job script with credentials and environment variables
+
+def jenkinsInfraRepo = 'https://shukla_deept@bitbucket.org/ncinga/jenkins-k8s.git'
+
+def cloneCredsId = 'bitbucket-readonly'
+
+def sbtCredsId   = 'sbt-publish-creds'
+
+// List of services to create pipeline jobs for
+
+def services = [
+    [name: 'n-authentication',          repo: 'https://shukla_deept@bitbucket.org/ncinga/nsp_auth.git'],
+    [name: 'n-machine-maintenance',     repo: 'https://shukla_deept@bitbucket.org/ncinga/zilingo-machine-maintenance-backend.git'],
+    [name: 'n-machine-maintenance-web', repo: 'https://shukla_deept@bitbucket.org/ncinga/zilingo-machine-maintenance-frontend.git']
+]
+
+services.each { service ->
+    def jobName = service.name
+    pipelineJob(jobName) {
+        description("Build Pipeline for ${jobName}")
+        properties {
+            disableConcurrentBuilds()
+            buildDiscarder {
+                strategy {
+                    logRotator {
+                        numToKeepStr('5')
+                        artifactNumToKeepStr('5')
+                    }
+                }
+            }
+            environmentVariables {
+                env('SERVICE_REPO_URL', service.repo)
+                env('SERVICE_NAME', jobName)
+                env('CREDENTIALS_ID', cloneCredsId)
+                env('SBT_CREDS_ID', sbtCredsId)
+            }
+        }
+        parameters {
+            stringParam('branch', 'master', 'Branch to build')
+            booleanParam('cleanBeforeCheckout', false, 'Clean workspace before checkout')
+            choiceParam('environmentType', ['none', 'stage', 'production'], 'Select environment type')
+            choiceParam('environment', ['kalpha'], 'Environment')
+        }
+        definition {
+            cpsScm {
+                scm {
+                    git {
+                        remote {
+                            url(jenkinsInfraRepo)
+                            credentials(cloneCredsId)
+                        }
+                        branches('*/master')
+                    }
+                }
+                scriptPath('jenkinsfiles/Jenkinsfile.backend-service')
+            }
+        }
+    }
+    println "✅ Created job: ${jobName}"
+}

--- a/docs/jcasc-snippet.yaml
+++ b/docs/jcasc-snippet.yaml
@@ -1,0 +1,22 @@
+jenkins:
+  credentials:
+    system:
+      domainCredentials:
+        - credentials:
+            - usernamePassword:
+                id: "bitbucket-readonly"
+                description: "Readonly Bitbucket access"
+                username: "${BITBUCKET_USER}"
+                password: "${BITBUCKET_PASS}"
+            - string:
+                id: "sbt-publish-creds"
+                description: "SBT publishing credential"
+                secret: "${SBT_TOKEN}"
+            - usernamePassword:
+                id: "aws-ecr-creds"
+                description: "AWS ECR access"
+                username: "${AWS_ACCESS_KEY_ID}"
+                password: "${AWS_SECRET_ACCESS_KEY}"
+  unclassified:
+    location:
+      url: "http://jenkins.example.com/"

--- a/docs/kaniko-pod.yaml
+++ b/docs/kaniko-pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+spec:
+  volumes:
+  - name: ivy-cache
+    emptyDir: {}
+  - name: sbt-creds
+    secret:
+      secretName: sbt-publish-creds
+      items:
+      - key: credentials
+        path: .credentials
+  - name: docker-config
+    configMap:
+      name: docker-config
+  containers:
+  - name: sbt
+    image: 185889327143.dkr.ecr.ap-southeast-1.amazonaws.com/sbt-0.13
+    command: ['cat']
+    tty: true
+    volumeMounts:
+    - name: ivy-cache
+      mountPath: /root/.ivy2/cache
+    - name: sbt-creds
+      mountPath: /root/.ivy2/.credentials
+      subPath: .credentials
+  - name: kaniko
+    image: gcr.io/kaniko-project/executor:v1.20.1
+    command: ['cat']
+    tty: true
+    volumeMounts:
+    - name: ivy-cache
+      mountPath: /root/.ivy2/cache
+    - name: docker-config
+      mountPath: /kaniko/.docker


### PR DESCRIPTION
## Summary
- add sample Groovy seed job with credentials
- add sample Jenkinsfile with SBT build and Kaniko push
- include example Docker config, Jenkins Dockerfile, JCasC snippet and pod YAML
- refine docs with secret and configmap instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c8bc96048325ad2f6cd5b07cb691